### PR TITLE
arm: evb-ast2600: put environment back at 512KiB

### DIFF
--- a/include/configs/evb_ast2600.h
+++ b/include/configs/evb_ast2600.h
@@ -18,7 +18,9 @@
 
 /* Environment */
 #define CONFIG_ENV_SIZE			0x10000
-#define CONFIG_ENV_OFFSET		0x90000
+#define CONFIG_ENV_OFFSET		0x60000
 #define CONFIG_ENV_SECT_SIZE		(4 << 10)
+#undef CONFIG_BOOTCOMMAND
+#define CONFIG_BOOTCOMMAND		"bootm 20080000"
 
 #endif	/* __CONFIG_H */


### PR DESCRIPTION
Prior to 473f430b90 the environment was at 512KiB, and compatible with
OpenBMC.  Restore OpenBMC compatibility by moving the environment back
to 512KiB.

Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>