### PR TITLE
ast2600/crypto: Fix SHA384 command register

### DIFF
--- a/arch/arm/mach-aspeed/ast2600/crypto.c
+++ b/arch/arm/mach-aspeed/ast2600/crypto.c
@@ -43,7 +43,7 @@ int aspeed_sg_digest(struct aspeed_sg_list *src_list, u32 list_length, u32 lengt
 		writel(0x40058, ASPEED_HACE_HASH_CMD);
 		break;
 	case ASPEED_SHA384:
-		writel(0x400468, ASPEED_HACE_HASH_CMD);
+		writel(0x40468, ASPEED_HACE_HASH_CMD);
 		break;
 	case ASPEED_SHA512:
 		writel(0x40068, ASPEED_HACE_HASH_CMD);


### PR DESCRIPTION
ASPEED_SHA384 is setting bits 22, 10, 6, 5, 3. None of the other
operations set 22, which is documented as reserved. Instead set 18 like
the others.

Signed-off-by: Joel Stanley <joel@jms.id.au>
