### PR TITLE
SDK v0.4.11 fixes

### DIFF
--- a/arch/arm/dts/ast2600.dtsi
+++ b/arch/arm/dts/ast2600.dtsi
@@ -796,7 +796,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x80 0x80 0xC00 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 110 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;
@@ -809,7 +809,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x100 0x80 0xC20 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 111 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;
@@ -822,7 +822,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x180 0x80 0xC40 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 112 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;
@@ -834,7 +834,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x200 0x40 0xC60 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 113 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;
@@ -846,7 +846,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x280 0x80 0xC80 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 114 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;
@@ -858,7 +858,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x300 0x40 0xCA0 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 115 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;
@@ -870,7 +870,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x380 0x80 0xCC0 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 116 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;
@@ -882,7 +882,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x400 0x80 0xCE0 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 117 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;
@@ -894,7 +894,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x480 0x80 0xD00 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 118 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;
@@ -906,7 +906,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x500 0x80 0xD20 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 119 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;
@@ -919,7 +919,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x580 0x80 0xD40 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 120 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;
@@ -932,7 +932,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x600 0x80 0xD60 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 121 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;
@@ -945,7 +945,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x680 0x80 0xD80 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 122 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;
@@ -958,7 +958,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x700 0x80 0xDA0 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 123 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;
@@ -971,7 +971,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x780 0x80 0xDC0 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 124 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;
@@ -984,7 +984,7 @@
 		#interrupt-cells = <1>;
 
 		reg = <0x800 0x80 0xDE0 0x20>;
-		compatible = "aspeed,ast2600-i2c";
+		compatible = "aspeed,ast2600-i2c-bus";
 		bus-frequency = <100000>;
 		interrupts = <GIC_SPI 125 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&scu ASPEED_CLK_APB2>;

--- a/cmd/Kconfig
+++ b/cmd/Kconfig
@@ -622,7 +622,6 @@ config CMD_OTP
 	select SHA384
 	select SHA256
 	select RSA
-	select ASPEED_ACRY
         default y
 
 config CMD_RNG

--- a/cmd/Kconfig
+++ b/cmd/Kconfig
@@ -616,11 +616,9 @@ menu "Device access commands"
 
 config CMD_OTP
 	depends on ASPEED_AST2600
+	depends on SHA256 && SHA384 && SHA512
         bool "ASPEED otp program"
-	select SHA512_ALGO
-	select SHA512
-	select SHA384
-	select SHA256
+	select HASH
 	select RSA
         default y
 

--- a/cmd/otp.c
+++ b/cmd/otp.c
@@ -2642,9 +2642,9 @@ static int otp_verify_boot_image(phys_addr_t addr)
 	int i;
 	int pass = 0;
 
-	ret = uclass_get_device_by_driver(UCLASS_MOD_EXP, DM_GET_DRIVER(aspeed_acry), &mod_exp_dev);
+	ret = uclass_get_device(UCLASS_MOD_EXP, 0, &mod_exp_dev);
 	if (ret) {
-		printf("RSA engine: Can't find aspeed_acry\n");
+		printf("RSA: Can't find RSA driver\n");
 		return OTP_FAILURE;
 	}
 

--- a/cmd/otp.c
+++ b/cmd/otp.c
@@ -133,11 +133,11 @@ struct otpstrap_status {
 };
 
 struct otpkey_type {
-	int value;
-	int key_type;
-	int order;
-	int need_id;
-	char information[110];
+	int value: 4;
+	int key_type: 4;
+	int order: 1;
+	int need_id: 1;
+	char *information;
 };
 
 struct otp_pro_sts {

--- a/drivers/i2c/aspeed_i2c_global.c
+++ b/drivers/i2c/aspeed_i2c_global.c
@@ -60,7 +60,8 @@ static int aspeed_i2c_global_probe(struct udevice *dev)
 
 	reset_deassert(&i2c_global->reset);
 
-	if (i2c_global->version == AST2600_I2C_GLOBAL) {
+	if (IS_ENABLED(SYS_I2C_AST2600) &&
+	    i2c_global->version == AST2600_I2C_GLOBAL) {
 		writel(AST2600_GLOBAL_INIT, i2c_global->regs +
 			AST2600_I2CG_CTRL);
 		writel(I2CCG_DIV_CTRL, i2c_global->regs +

--- a/drivers/i2c/ast2600_i2c.c
+++ b/drivers/i2c/ast2600_i2c.c
@@ -385,7 +385,7 @@ static const struct dm_i2c_ops ast2600_i2c_ops = {
 };
 
 static const struct udevice_id ast2600_i2c_ids[] = {
-	{ .compatible = "aspeed,ast2600-i2c" },
+	{ .compatible = "aspeed,ast2600-i2c-bus" },
 	{},
 };
 


### PR DESCRIPTION
These fixes address image size and I2C compatibility issues identified in the latest SDK release.