### PR TITLE
arm/mach-aspeed: Add support for CONFIG_ASPEED_ROUTE_UART5_TO_UART1

### DIFF
--- a/arch/arm/mach-aspeed/Kconfig
+++ b/arch/arm/mach-aspeed/Kconfig
@@ -54,6 +54,13 @@ config ASPEED_PALLADIUM
 	  This is mainly for internal verification and investigation
 	  on HW design. If not sure, say N.
 
+config ASPEED_ROUTE_UART5_TO_UART1
+	bool "Route UART5 console to UART1 pins"
+	depends on ASPEED_AST2500
+	help
+	  Route UART5 console to TXD1/RXD1 pins instead of TXD5/RXD5 pins.
+	  Does not affect the debug uart functionality.
+
 config ASPEED_SSP_RERV_MEM
 	hex "Reserve memory for SSP"
 	default 0x0

--- a/arch/arm/mach-aspeed/ast2500/platform.S
+++ b/arch/arm/mach-aspeed/ast2500/platform.S
@@ -795,7 +795,7 @@ wait_ddr_reset:
     /* end delay 10ms */
 
 /* Debug - UART console message */
-#ifdef CONFIG_DRAM_UART_TO_UART1
+#ifdef CONFIG_ASPEED_ROUTE_UART5_TO_UART1
     ldr   r0, =0x1e78909c                        @ route UART5 to UART Port1, 2016.08.29
     ldr   r1, =0x10000004
     str   r1, [r0]


### PR DESCRIPTION
Introduce CONFIG_ASPEED_ROUTE_UART5_TO_UART1 and reuse existing platform code to route UART5 to UART1 pins.
This is required on IBM/Genesis3 as only UART5 can be used as early debug console, but the RXD1/TXD1 pins are connected instead of RXD5/TXD5. This does not affect the "debug UART" function on RXD{1,5}.

The symbol name is changed to improve readability.
